### PR TITLE
Removed default hash salt

### DIFF
--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -12,9 +12,6 @@
 //
 extract((new Druidfi\Omen\DrupalEnvDetector(__DIR__))->getConfiguration());
 
-// Hash salt.
-$settings['hash_salt'] = 'oNbAEGiCIhNhXU-hNBmZMLSSR11HUqnXVUdG9IwMDFBft67IXRV4xjao1W20AQ_O5pRQ07PNMg';
-
 /**
  * Only in Wodby environment. @see https://wodby.com/docs/stacks/drupal/#overriding-settings-from-wodbysettingsphp
  */


### PR DESCRIPTION
At the moment every project is using the same hash salt unless explicitly overridden.

Maybe we should check if hash salt is set in when running `make new`  or `make fresh` (or whenever you think it's easiest to do) and generate one if not set?