### PR TITLE
Fixed drupal custom theme and module installer names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,10 +48,10 @@
             "public/core": ["type:drupal-core"],
             "public/libraries/{$name}": ["type:drupal-library"],
             "public/modules/contrib/{$name}": ["type:drupal-module"],
-            "public/modules/custom/{$name}": ["type:drupal-module-custom"],
+            "public/modules/custom/{$name}": ["type:drupal-custom-module"],
             "public/profiles/{$name}": ["type:drupal-profile"],
             "public/themes/contrib/{$name}": ["type:drupal-theme"],
-            "public/themes/custom/{$name}": ["type:drupal-theme-custom"],
+            "public/themes/custom/{$name}": ["type:drupal-custom-theme"],
             "drush/{$name}": ["type:drupal-drush"]
         }
     },


### PR DESCRIPTION
Installer types for custom modules and themes are actually called `drupal-custom-module` and `drupal-custom-theme`.

See: https://github.com/composer/installers#current-supported-package-types