### PR TITLE
Install drush commands to correct folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore project files that should not be in version control
 drush/sites/
+drush/Commands/*/
 node_modules
 public/core
 public/libraries

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
             "public/themes/custom/{$name}": [
                 "type:drupal-custom-theme"
             ],
-            "drush/{$name}": [
+            "drush/Commands/{$name}": [
                 "type:drupal-drush"
             ]
         }


### PR DESCRIPTION
Site wide drush command files are installed to `drush/${name}` folder and are never loaded by Drush.

See: https://docs.drush.org/en/9.x/commands/#site-wide-drush-commands