### PR TITLE
Add host.docker.internal as extra_hosts to support xdebug out of the box on linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-app.tls=true"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}-app.loadbalancer.server.port=8080"
       - "traefik.docker.network=stonehenge-network"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - internal
       - stonehenge-network


### PR DESCRIPTION
We've been using this for quite a while already and it seems to work on osx/windows too.