### PR TITLE
Use environment variable to control whether xdebug should be enabled or not

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       DRUPAL_ROUTES: "https://varnish-${DRUPAL_HOSTNAME}"
       DRUSH_OPTIONS_URI: "https://${DRUPAL_HOSTNAME}"
       PHP_SENDMAIL_PATH: "/usr/sbin/sendmail -S stonehenge-mailhog:1025"
-      #XDEBUG_ENABLE: "true"
+      # Run `export XDEBUG_ENABLE=true` to enable xdebug.
+      XDEBUG_ENABLE: "${XDEBUG_ENABLE:-false}"
       SIMPLETEST_BASE_URL: "http://app:8080"
       SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
     labels:


### PR DESCRIPTION
It's pretty frustrating to always remember to enable xdebug, especially when working in a team with multiple mac users, who usually want to have xdebug disabled by default.

Not sure if there's a better way to do this, but this way I can just set `export XDEBUG_ENABLE=true` and never have to deal with it again.