### PR TITLE
Wait for Drush web server to start before running tests, upload test results as artifact

### DIFF
--- a/.github/workflows/drupal.yml
+++ b/.github/workflows/drupal.yml
@@ -95,11 +95,7 @@ jobs:
 
       - name: Run PHPUnit tests
         run: |
-          set -o pipefail && vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testdox --verbose | tee phpunit-result.txt
-          cat phpunit-result.txt | grep -q "✔ Unit test"
-          cat phpunit-result.txt | grep -q "✔ Kernel test"
-          cat phpunit-result.txt | grep -q "✔ Functional test"
-          cat phpunit-result.txt | grep -q "✔ Javascript test"
+          set -o pipefail && vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --verbose
 
       - name: Create an artifact from test report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/drupal.yml
+++ b/.github/workflows/drupal.yml
@@ -81,13 +81,16 @@ jobs:
       - name: Operate on Drupal
         run: |
           vendor/bin/drush status
-          composer require --no-progress drupal/metatag
-          vendor/bin/drush en --yes metatag
+          composer require --no-progress drupal/filelog
+          vendor/bin/drush en --yes filelog
 
       - name: Run web server with Drush
         run: |
           vendor/bin/drush runserver $SIMPLETEST_BASE_URL > /dev/null 2>&1 &
           chromedriver --port=4444 &
+
+      - name: Wait for web server to start
+        run: for i in {1..5}; do RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$SIMPLETEST_BASE_URL" || true); if [ "$RESPONSE_CODE" -gt "301" ] || [ "$RESPONSE_CODE" -lt "200" ]; then sleep 2; fi; done
 
       - name: Run PHPUnit tests
         run: |
@@ -97,4 +100,12 @@ jobs:
           cat phpunit-result.txt | grep -q "✔ Functional test"
           cat phpunit-result.txt | grep -q "✔ Javascript test"
 
-
+      - name: Create an artifact from test report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: results
+          path: |
+            public/sites/simpletest/browser_output/
+            public/sites/default/files/logs/drupal.log
+          retention-days: 1

--- a/.github/workflows/drupal.yml
+++ b/.github/workflows/drupal.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Operate on Drupal
         run: |
           vendor/bin/drush status
-          composer require --no-progress drupal/filelog
-          vendor/bin/drush en --yes filelog
+          composer require --no-progress drupal/metatag
+          vendor/bin/drush en --yes metatag
 
       - name: Run web server with Drush
         run: |
@@ -105,7 +105,5 @@ jobs:
         if: always()
         with:
           name: results
-          path: |
-            public/sites/simpletest/browser_output/
-            public/sites/default/files/logs/drupal.log
+          path: public/sites/simpletest/browser_output/
           retention-days: 1

--- a/.github/workflows/drupal.yml
+++ b/.github/workflows/drupal.yml
@@ -16,6 +16,7 @@ env:
   DRUPAL_INSTALL_PROFILE: minimal
   SIMPLETEST_DB: mysql://drupal:drupal@127.0.0.1:3306/drupal
   SIMPLETEST_BASE_URL: http://127.0.0.1:8080
+  BROWSERTEST_OUTPUT_DIRECTORY: 'public/sites/simpletest'
 
 jobs:
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
          failOnWarning="true"
+         failOnRisky="true"
          printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
          cacheResult="false">
   <php>


### PR DESCRIPTION
At the moment it's possible for tests to fail (not very often) because Drush web server is still starting up. I've also added a step that uploads test results as github artifact to make debugging them easier.