### PR TITLE
Replaced "set-output" calls with environment files

### DIFF
--- a/.github/workflows/drupal.yml
+++ b/.github/workflows/drupal.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
`::set-output` is deprecated and should be replaced with environment files:

![image](https://user-images.githubusercontent.com/771113/207621731-21c4dea8-1777-40f5-92c0-9c516ccff95f.png)

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/