### PR TITLE
Fixed drush commands folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
             "public/profiles/{$name}": ["type:drupal-profile"],
             "public/themes/contrib/{$name}": ["type:drupal-theme"],
             "public/themes/custom/{$name}": ["type:drupal-theme-custom"],
-            "drush/{$name}": ["type:drupal-drush"]
+            "drush/Commands/{$name}": ["type:drupal-drush"]
         }
     },
     "repositories": [


### PR DESCRIPTION
Looks like #32 was reverted in https://github.com/druidfi/spell/commit/720b1faa515d189b37cb8bace4dc36933f287934