### PR TITLE
Use COMPOSE_PROJECT_NAME as hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   app:
     container_name: ${COMPOSE_PROJECT_NAME}-app
-    hostname: ${DRUPAL_HOSTNAME}
+    hostname: ${COMPOSE_PROJECT_NAME}
     image: druidfi/drupal-web:php-${PHP_VERSION}
     volumes:
       - .:/app:delegated


### PR DESCRIPTION
Alpine or Docker (not sure which) seems to fallback all non-existent domains (like `app`, `elastic`) to `127.0.0.1` if hostname is set to `xxxx.docker.so`.